### PR TITLE
Fix token error detection

### DIFF
--- a/plugin.video.ivysilani/ivysilani.py
+++ b/plugin.video.ivysilani/ivysilani.py
@@ -348,7 +348,7 @@ def _fetch(url, params):
 	data = _https_ceska_televize_fetch(url, params)
 	root = ET.fromstring(data)
 	if root.tag == "errors":
-		if root[0].text == "no _token sent" or root[0].text == "wrong _token":
+		if root[0].text == "no token sent" or root[0].text == "wrong token":
 			_token_refresh()
 			data = _https_ceska_televize_fetch(url, params)
 		else:


### PR DESCRIPTION
ivysilani pri neplatnom/nezadanom token, nerefreshne token ale vyhlasi chybu:
```
>>> reload(ivysilani)
<module 'ivysilani' from 'ivysilani.pyc'>
>>> ivysilani._token = 11
>>> ivysilani._fetch(ivysilani.ALPHABETLIST_URL,{})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "ivysilani.py", line 355, in _fetch
    raise Exception(', '.join([e.text for e in root]))
Exception: wrong token
```